### PR TITLE
#24 cherry-pick, add simple blocker component

### DIFF
--- a/druid/base/blocker.lua
+++ b/druid/base/blocker.lua
@@ -1,0 +1,33 @@
+--- Component to block input on specify zone (node)
+-- @module base.blocker
+
+local const = require("druid.const")
+local helper = require("druid.helper")
+
+
+local M = {}
+M.interest = {
+	const.ON_SWIPE
+}
+
+
+function M.init(self, node)
+	self.node = helper.get_node(node)
+	self.event = const.ACTION_TOUCH
+end
+
+
+function M.on_input(self, action_id, action)
+	if not helper.is_enabled(self.node) then
+		return false
+	end
+
+	if gui.pick_node(self.node, action.x, action.y) then
+		return true
+	end
+
+	return false
+end
+
+
+return M

--- a/druid/druid.lua
+++ b/druid/druid.lua
@@ -9,6 +9,7 @@ local _fct_metatable = {}
 
 M.comps = {
 	button = require("druid.base.button"),
+	blocker = require("druid.base.blocker"),
 	android_back = require("druid.base.android_back"),
 	text = require("druid.base.text"),
 	timer = require("druid.base.timer"),


### PR DESCRIPTION
Resolve #24 

Blocker component need to block any Druid input.

Use case: to implement tap on window background to closing window
All gui scene is close button, but window itself is blocker.

_This is cherry pick from druid_example to better PR changes_