### PR TITLE
Optimize Mobile/Web detection

### DIFF
--- a/druid/const.lua
+++ b/druid/const.lua
@@ -51,6 +51,10 @@ M.PIVOTS = {
 }
 
 
+M.SYS_INFO = sys.get_sys_info()
+M.CURRENT_SYSTEM_NAME = M.SYS_INFO.system_name
+
+
 M.OS = {
 	ANDROID = "Android",
 	IOS = "iPhone OS",

--- a/druid/helper.lua
+++ b/druid/helper.lua
@@ -5,6 +5,7 @@ local const = require("druid.const")
 
 local M = {}
 
+local system_name = sys.get_sys_info().system_name
 
 --- Text node or icon node can be nil
 local function get_text_width(text_node)
@@ -182,15 +183,13 @@ end
 --- Check if device is mobile (Android or iOS)
 -- @function helper..is_mobile
 function M.is_mobile()
-	local system_name = sys.get_sys_info().system_name
-	return system_name == const.OS.IOS or system_name == const.OS.ANDROID
+	return system_name == const.OS.IOS or SYSTEM_NAME == const.OS.ANDROID
 end
 
 
 --- Check if device is HTML5
 -- @function helper.is_web
 function M.is_web()
-	local system_name = sys.get_sys_info().system_name
 	return system_name == const.OS.BROWSER
 end
 

--- a/druid/helper.lua
+++ b/druid/helper.lua
@@ -183,14 +183,14 @@ end
 --- Check if device is mobile (Android or iOS)
 -- @function helper..is_mobile
 function M.is_mobile()
-	return system_name == const.OS.IOS or SYSTEM_NAME == const.OS.ANDROID
+	return const.CURRENT_SYSTEM_NAME == const.OS.IOS or const.CURRENT_SYSTEM_NAME == const.OS.ANDROID
 end
 
 
 --- Check if device is HTML5
 -- @function helper.is_web
 function M.is_web()
-	return system_name == const.OS.BROWSER
+	return const.CURRENT_SYSTEM_NAME == const.OS.BROWSER
 end
 
 


### PR DESCRIPTION
I found that my web game generates a lot of warnings on taps and mouse clicks in the debug build:
```
WARNING:DLIB: No territory detected in language string: "ru"
```

Also, I figured out that Druid frequently calls `is_mobile()` and `is_web()` which calls `sys.get_sys_info()`. Every call of `sys.get_sys_info()` makes a new table and fills it with the system data.
I think it is an expensive operation and it should be cached. Therefore, the warning would be shown only once :) 
