### PR TITLE
Added `@generic T` to the methods that returns the passed component t…

### DIFF
--- a/druid/annotations.lua
+++ b/druid/annotations.lua
@@ -111,9 +111,10 @@ function druid__base_component.reset_input_priority(self) end
 
 --- Set component input state.
 --- By default it enabled  If input is disabled, the component will not receive input events
----@param self druid.base_component @{BaseComponent}
+---@generic T: druid.base_component
+---@param self T @{BaseComponent}
 ---@param state boolean|nil The component input state
----@return druid.base_component BaseComponent itself
+---@return T BaseComponent itself
 function druid__base_component.set_input_enabled(self, state) end
 
 --- Set component input priority
@@ -126,23 +127,26 @@ function druid__base_component.set_input_priority(self, value, is_temporary) end
 
 --- Set current component nodes.
 --- Use if your component nodes was cloned with `gui.clone_tree` and you got the node tree.
----@param self druid.base_component @{BaseComponent}
+---@generic T: druid.base_component
+---@param self T @{BaseComponent}
 ---@param nodes table BaseComponent nodes table
----@return druid.base_component @{BaseComponent}
+---@return T @{BaseComponent}
 function druid__base_component.set_nodes(self, nodes) end
 
 --- Set current component style table.
 --- Invoke `on_style_change` on component, if exist. Component should handle  their style changing and store all style params
----@param self druid.base_component @{BaseComponent}
+---@generic T: druid.base_component
+---@param self T @{BaseComponent}
 ---@param druid_style table|nil Druid style module
----@return druid.base_component @{BaseComponent}
+---@return T @{BaseComponent}
 function druid__base_component.set_style(self, druid_style) end
 
 --- Set component template name.
 --- Use on all your custom components with GUI layouts used as templates.  It will check parent template name to build full template name in self:get_node()
----@param self druid.base_component @{BaseComponent}
+---@generic T: druid.base_component
+---@param self T @{BaseComponent}
 ---@param template string BaseComponent template name
----@return druid.base_component @{BaseComponent}
+---@return T @{BaseComponent}
 function druid__base_component.set_template(self, template) end
 
 
@@ -1463,10 +1467,11 @@ local druid_instance = {}
 function druid_instance.final(self) end
 
 --- Create new component.
+---@generic T: druid.base_component
 ---@param self druid_instance
----@param component druid.base_component Component module
+---@param component T Component module
 ---@param ... any Other component params to pass it to component:init function
----@return druid.base_component Component instance
+---@return T Component instance
 function druid_instance.new(self, component, ...) end
 
 --- Create @{BackHandler} component

--- a/druid/annotations.lua
+++ b/druid/annotations.lua
@@ -50,13 +50,6 @@ local druid__back_handler = {}
 ---@class druid.base_component
 local druid__base_component = {}
 
---- Set current component style table.
---- Invoke `on_style_change` on component, if exist. Component should handle  their style changing and store all style params
----@param self druid.base_component @{BaseComponent}
----@param druid_style table|nil Druid style module
----@return druid.base_component @{BaseComponent}
-function druid__base_component.component:set_style(self, druid_style) end
-
 --- Return all children components, recursive
 ---@param self druid.base_component @{BaseComponent}
 ---@return table Array of childrens if the Druid component instance
@@ -137,6 +130,13 @@ function druid__base_component.set_input_priority(self, value, is_temporary) end
 ---@param nodes table BaseComponent nodes table
 ---@return druid.base_component @{BaseComponent}
 function druid__base_component.set_nodes(self, nodes) end
+
+--- Set current component style table.
+--- Invoke `on_style_change` on component, if exist. Component should handle  their style changing and store all style params
+---@param self druid.base_component @{BaseComponent}
+---@param druid_style table|nil Druid style module
+---@return druid.base_component @{BaseComponent}
+function druid__base_component.set_style(self, druid_style) end
 
 --- Set component template name.
 --- Use on all your custom components with GUI layouts used as templates.  It will check parent template name to build full template name in self:get_node()
@@ -562,14 +562,15 @@ local druid__hotkey = {}
 --- Add hotkey for component callback
 ---@param self druid.hotkey @{Hotkey}
 ---@param keys string[]|hash[]|string|hash that have to be pressed before key pressed to activate
----@param callback_argument value The argument to pass into the callback function
+---@param callback_argument any|nil The argument to pass into the callback function
+---@return druid.hotkey Current instance
 function druid__hotkey.add_hotkey(self, keys, callback_argument) end
 
---- Component init function
+--- The @{Hotkey} constructor
 ---@param self druid.hotkey @{Hotkey}
 ---@param keys string[]|string The keys to be pressed for trigger callback. Should contains one key and any modificator keys
 ---@param callback function The callback function
----@param callback_argument value The argument to pass into the callback function
+---@param callback_argument any|nil The argument to pass into the callback function
 function druid__hotkey.init(self, keys, callback, callback_argument) end
 
 --- If true, the callback will be triggered on action.repeated

--- a/druid/component.lua
+++ b/druid/component.lua
@@ -74,7 +74,6 @@ end
 --
 -- Invoke `on_style_change` on component, if exist. Component should handle
 -- their style changing and store all style params
--- @function component:set_style
 -- @tparam BaseComponent self @{BaseComponent}
 -- @tparam table|nil druid_style Druid style module
 -- @treturn BaseComponent @{BaseComponent}


### PR DESCRIPTION
Added the generic type T to the annotations to avoid type loss during the component instance creating.

Example of the solved problem:

```lua
-- some component
---@class pocket_view: druid.base_component
...
-- some class property
---@field pocket_view pocket_view
...
-- assigning
self.pocket_view = self.druid:new(PocketView, 'pocket')
-- Warning that the returned class druid.base_component is not the expected pocket_view
...
```