### PR TITLE
Fix missing text when the input selected again and type new text

### DIFF
--- a/druid/extended/input.lua
+++ b/druid/extended/input.lua
@@ -313,6 +313,7 @@ end
 function Input.unselect(self)
 	gui.reset_keyboard()
 	self.marked_value = ""
+	self.value = self.current_value
 	if self.is_selected then
 		self:reset_input_priority()
 		self.button:reset_input_priority()


### PR DESCRIPTION
Checking on mobile (Android), for Vietnamese keyboard, when typing without pressing space bar, the typed text is all marked text and not updated to the self.value variable (when pressing space, the marked text will be dropped and replaced by a normal text). This leads to missing the typed text when the input selected again and type new text