### PR TITLE
Fix consume input issue when having marked text

### DIFF
--- a/druid/extended/input.lua
+++ b/druid/extended/input.lua
@@ -166,7 +166,7 @@ end
 function Input.on_input(self, action_id, action)
 	if self.is_selected then
 		local input_text = nil
-		local marked_text = ""
+		local marked_text = nil
 		if action_id == const.ACTION_TEXT then
 			-- ignore return key
 			if action.text == "\n" or action.text == "\r" then
@@ -219,7 +219,7 @@ function Input.on_input(self, action_id, action)
 			return true
 		end
 
-		if input_text or #marked_text > 0 then
+		if input_text or marked_text then
 			self:set_text(input_text)
 			return true
 		end

--- a/druid/extended/input.lua
+++ b/druid/extended/input.lua
@@ -219,7 +219,7 @@ function Input.on_input(self, action_id, action)
 			return true
 		end
 
-		if input_text or #marked_text then
+		if input_text or #marked_text > 0 then
 			self:set_text(input_text)
 			return true
 		end

--- a/druid/extended/input.lua
+++ b/druid/extended/input.lua
@@ -166,6 +166,7 @@ end
 function Input.on_input(self, action_id, action)
 	if self.is_selected then
 		local input_text = nil
+		local marked_text = ""
 		if action_id == const.ACTION_TEXT then
 			-- ignore return key
 			if action.text == "\n" or action.text == "\r" then
@@ -196,6 +197,7 @@ function Input.on_input(self, action_id, action)
 			if self.max_length then
 				self.marked_value = utf8.sub(self.marked_value, 1, self.max_length)
 			end
+			marked_text = self.marked_value
 		end
 
 		if action_id == const.ACTION_BACKSPACE and (action.pressed or action.repeated) then
@@ -217,7 +219,7 @@ function Input.on_input(self, action_id, action)
 			return true
 		end
 
-		if input_text or #self.marked_value > 0 then
+		if input_text or #marked_text then
 			self:set_text(input_text)
 			return true
 		end


### PR DESCRIPTION
When having marked text, the variable self.marked_value makes the input consume until pressing space or unselected.