### PR TITLE
Fix sender type for `druid_instance.on_message()`

### DIFF
--- a/druid/annotations.lua
+++ b/druid/annotations.lua
@@ -1653,7 +1653,7 @@ function druid_instance.on_input(self, action_id, action) end
 ---@param self druid_instance
 ---@param message_id hash Message_id from on_message
 ---@param message table Message from on_message
----@param sender hash Sender from on_message
+---@param sender url Sender from on_message
 function druid_instance.on_message(self, message_id, message, sender) end
 
 --- Remove created component from Druid instance.


### PR DESCRIPTION
Even though there is no sender parameter in the [gui documentation](https://defold.com/ref/stable/gui/#on_message:self-message_id-message), really it comes with a url, not a hash.

<img width="1109" alt="Screenshot 2024-06-12 at 12 19 58" src="https://github.com/Insality/druid/assets/4752473/4b2e7cd3-3e2e-4a8a-bf3a-d5c88b582735">

In the [go documentation](dhttps://defold.com/ref/stable/go/#on_message:self-message_id-message-sender) it's also url.