### PR TITLE
Fix scroll jitter in extro zone on Android 60Hz displays

### DIFF
--- a/druid/base/scroll.lua
+++ b/druid/base/scroll.lua
@@ -525,27 +525,34 @@ function M:_check_soft_zone()
 	local target = self.target_position
 	local border = self.available_pos
 	local speed = self.style.BACK_SPEED
+	local affected = false
 
 	-- Right border (minimum x)
 	if target.x < border.x then
 		local step = math.max(math.abs(target.x - border.x) * speed, 1)
-		target.x = helper.step(target.x, border.x, step)
+        target.x = helper.step(target.x, border.x, step)
+		affected = true
 	end
 	-- Left border (maximum x)
 	if target.x > border.z then
 		local step = math.max(math.abs(target.x - border.z) * speed, 1)
 		target.x = helper.step(target.x, border.z, step)
+		affected = true
 	end
 	-- Top border (maximum y)
 	if target.y < border.y then
 		local step = math.max(math.abs(target.y - border.y) * speed, 1)
 		target.y = helper.step(target.y, border.y, step)
+		affected = true
 	end
 	-- Bot border (minimum y)
 	if target.y > border.w then
 		local step = math.max(math.abs(target.y - border.w) * speed, 1)
 		target.y = helper.step(target.y, border.w, step)
+		affected = true
 	end
+
+	return affected
 end
 
 
@@ -675,7 +682,10 @@ function M:_update_free_scroll(dt)
 	-- Inertion friction
 	self.inertion = self.inertion * self.style.FRICT
 
-	self:_check_soft_zone()
+	local affected = self:_check_soft_zone()
+	if affected then
+		self.inertion = vmath.vector3(0, 0, 0)
+	end
 	if self.position.x ~= target.x or self.position.y ~= target.y then
 		self:_set_scroll_position(target.x, target.y)
 	end


### PR DESCRIPTION
This PR resolves a scroll jitter issue occurring during fast scrolling on Android devices with 60Hz displays (120Hz devices were unaffected). The problem occurred when scrolling reached extro/soft zones, where residual inertia caused visible shaking.
**Key Changes:**
1. **Inertia Reset Logic**
2. **Soft-Zone Detection Enhancement**

Bug reproduction video (60Hz): [video](https://drive.google.com/file/d/1riFju4_VMuyrHVSJnCYb92roIicXSwOx/view?usp=sharing)