### PR TITLE
Create ext.properties

### DIFF
--- a/druid/ext.properties
+++ b/druid/ext.properties
@@ -1,0 +1,35 @@
+[druid]
+help = Settings for Druid extension
+group = Runtime
+
+input_text.default = text
+
+input_touch.default = touch
+
+input_marked_text.default = marked_text
+
+input_key_esc.default = key_esc
+
+input_key_back.default = key_back
+
+input_key_enter.default = key_enter
+
+input_key_backspace.default = key_backspace
+
+input_multitouch.default = touch_multi
+
+input_scroll_up.default = mouse_wheel_up
+
+input_scroll_down.default = mouse_wheel_down
+
+input_key_left.default = key_left
+
+input_key_right.default = key_right
+
+input_key_lshift.default = key_lshift
+
+input_key_lctrl.default = key_lctrl
+
+input_key_lsuper.default = key_lsuper
+
+no_auto_input.type = bool


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to show extension settings in the `game.project` form. This PR adds `ext.properties` to show used settings:
<img width="846" height="826" alt="Screenshot 2025-08-22 at 14 38 17" src="https://github.com/user-attachments/assets/d16f174c-cab4-4059-a5f2-94ea83fb47b9" />
