### PR TITLE
Fix disabled button consumes input

### DIFF
--- a/druid/base/button.lua
+++ b/druid/base/button.lua
@@ -144,6 +144,10 @@ end
 ---@param action table The action table
 ---@return boolean is_consumed True if the input was consumed
 function M:on_input(action_id, action)
+	if self.disabled then 
+		return
+	end
+	
 	if not self:_is_input_match(action_id) then
 		return false
 	end


### PR DESCRIPTION
Hi!
We noticed that when two buttons are stacked one above another, a disabled button still consumes input. To ensure correct behavior, we now use the following code:
```
self.button:set_enabled(enabled)
self.button:set_input_enabled(enabled)
```