### PR TITLE
Release 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ https://github.com/Insality/defold-event/archive/refs/tags/14.zip
 **[Druid](https://github.com/Insality/druid/)**
 
 ```
-https://github.com/Insality/druid/archive/refs/tags/1.2.2.zip
+https://github.com/Insality/druid/archive/refs/tags/1.2.3.zip
 ```
 
 After that, select `Project ▸ Fetch Libraries` to update [library dependencies]((https://defold.com/manuals/libraries/#setting-up-library-dependencies)). This happens automatically whenever you open a project so you will only need to do this if the dependencies change without re-opening the project.

--- a/druid/base/hover.lua
+++ b/druid/base/hover.lua
@@ -20,6 +20,7 @@ local component = require("druid.component")
 ---@field private _is_mobile boolean True if the platform is mobile
 local M = component.create("hover")
 
+local IS_MOBILE = helper.is_mobile()
 
 ---The constructor for the hover component
 ---@param node node Gui node
@@ -31,7 +32,6 @@ function M:init(node, on_hover_callback, on_mouse_hover)
 	self._is_hovered = false
 	self._is_mouse_hovered = false
 	self._is_enabled = true
-	self._is_mobile = helper.is_mobile()
 
 	self.on_hover = event.create(on_hover_callback)
 	self.on_mouse_hover = event.create(on_mouse_hover)
@@ -68,7 +68,7 @@ function M:on_input(action_id, action)
 	end
 
 	-- Disable nil (it's mouse) hover or mobile platforms
-	if self._is_mobile and not action_id then
+	if IS_MOBILE and not action_id then
 		return false
 	end
 

--- a/druid/editor_scripts/create_druid_collection.lua
+++ b/druid/editor_scripts/create_druid_collection.lua
@@ -22,7 +22,7 @@ function M.create_druid_collection(selection)
 	local template = [[name: "%s"
 scale_along_z: 0
 embedded_instances {
-  id: "go"
+  id: "root"
   data: "components {\n"
   "  id: \"%s\"\n"
   "  component: \"%s\"\n"

--- a/druid/extended/hotkey.lua
+++ b/druid/extended/hotkey.lua
@@ -151,14 +151,17 @@ function M:on_input(action_id, action)
 			local is_modificator_ok = true
 			local is_consume = not not (hotkey.key)
 
-			-- Check only required modificators pressed
-			if hotkey.key and #hotkey.modificators > 0 then
+			if hotkey.key then
 				for i = 1, #self.style.MODIFICATORS do
 					local mod = self.style.MODIFICATORS[i]
-					if helper.contains(hotkey.modificators, mod) and self._modificators[mod] == false then
-						is_modificator_ok = false
-					end
-					if not helper.contains(hotkey.modificators, mod) and self._modificators[mod] == true then
+					if #hotkey.modificators > 0 then
+						if helper.contains(hotkey.modificators, mod) and self._modificators[mod] == false then
+							is_modificator_ok = false
+						end
+						if not helper.contains(hotkey.modificators, mod) and self._modificators[mod] == true then
+							is_modificator_ok = false
+						end
+					elseif self._modificators[mod] == true then
 						is_modificator_ok = false
 					end
 				end

--- a/game.project
+++ b/game.project
@@ -14,7 +14,7 @@ update_frequency = 60
 
 [project]
 title = Druid
-version = 1.2.2
+version = 1.2.3
 publisher = Insality
 developer = Maksim Tuprikov
 custom_resources = /example/locales
@@ -60,7 +60,7 @@ cssfile = /builtins/manifests/web/dark_theme.css
 show_console_banner = 0
 
 [native_extension]
-app_manifest = 
+app_manifest =
 
 [graphics]
 texture_profiles = /builtins/graphics/default.texture_profiles

--- a/test/tests/test_druid_instance.lua
+++ b/test/tests/test_druid_instance.lua
@@ -285,6 +285,29 @@ return function()
 			druid_instance:remove(hotkey)
 		end)
 
+		it("Should not trigger hotkey without modificators when modificator is pressed", function()
+			local on_hotkey_calls = 0
+			local function on_hotkey()
+				on_hotkey_calls = on_hotkey_calls + 1
+			end
+
+			local hotkey = druid_instance:new_hotkey("key_q", on_hotkey)
+
+			druid_instance:on_input(mock_input.key_pressed("key_lshift"))
+			druid_instance:on_input(mock_input.key_pressed("key_q"))
+			druid_instance:on_input(mock_input.key_released("key_q"))
+			druid_instance:on_input(mock_input.key_released("key_lshift"))
+
+			assert(on_hotkey_calls == 0)
+
+			druid_instance:on_input(mock_input.key_pressed("key_q"))
+			druid_instance:on_input(mock_input.key_released("key_q"))
+
+			assert(on_hotkey_calls == 1)
+
+			druid_instance:remove(hotkey)
+		end)
+
 		it("Should create container component", function()
 			local parent_node = gui.new_box_node(vmath.vector3(150, 100, 0), vmath.vector3(300, 200, 0))
 

--- a/wiki/changelog.md
+++ b/wiki/changelog.md
@@ -822,3 +822,7 @@ Please support me if you like this project! It will help me keep engaged to upda
 - [Data List] Fix for visible bounds calculation in matrix grid mode
 - [Scroll] Fix for `scroll_to_make_node_visible` for some cases
 - [Layout] Refresh layout component when window layout is changed
+
+### Druid 1.2.3
+- [Hotkey] Should not trigger hotkey without modificators when modificator is pressed
+- [Editor Scripts] Rename go -> root to druid game collection from editor scripts


### PR DESCRIPTION
### Druid 1.2.3
- [Hotkey] Should not trigger hotkey without modificators when modificator is pressed
- [Editor Scripts] Rename go -> root to druid game collection from editor scripts